### PR TITLE
Adds analytics tracking env setup to ui chart

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -9,3 +9,4 @@ data:
   search_enabled: {{ .Values.config.search.enabled | quote }}
   search_url: '{{ .Values.config.search.url }}'
   workspaces_enabled: {{ .Values.config.workspaces.enabled | quote }}
+  analytics: {{ .Values.config.analytics | quote }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -72,6 +72,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "ui.fullname" . }}-config
                   key: search_url
+            - name: REACT_APP_ANLAYTICS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ui.fullname" . }}-config
+                  key: analytics
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -63,6 +63,12 @@ config:
     url: 'https:\/\/helx.renci.org'
   workspaces:
     enabled: "true"
+  analytics:
+    enabled: true
+    platform: "mixpanel"
+    auth:
+      mixpanel_token:  "0c39f8410fd548bfa1976957d0248289"
+      ga_property: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/values.yaml
+++ b/values.yaml
@@ -63,12 +63,15 @@ config:
     url: 'https:\/\/helx.renci.org'
   workspaces:
     enabled: "true"
-  analytics:
-    enabled: true
-    platform: "mixpanel"
-    auth:
-      mixpanel_token:  "0c39f8410fd548bfa1976957d0248289"
-      ga_property: ""
+  analytics: >-
+    {
+      "enabled": true,
+      "platform": "mixpanel",
+      "auth": {
+        "mixpanel_token":  "0c39f8410fd548bfa1976957d0248289",
+        "ga_property": ""
+      }
+    }
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Sets up the environment for analytics tracking.

Note: currently, it's using a token which refers to a personal mixpanel project.