### PR TITLE
Adds tranql url env

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
   workspaces_enabled: {{ .Values.config.workspaces.enabled | quote }}
   analytics: {{ .Values.config.analytics.token | quote }}
   tranql_enabled: {{ .Values.config.tranql_enabled | quote }}
+  tranql_url: {{ .Values.config.tranql_url | quote }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -82,6 +82,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "ui.fullname" . }}-config
                   key: tranql_enabled
+            - name: REACT_APP_TRANQL_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ui.fullname" . }}-config
+                  key: tranql_url
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -66,6 +66,7 @@ config:
   analytics:
     token: "0c39f8410fd548bfa1976957d0248289"
   tranql_enabled: "true"
+  tranql_url: "https://helx.renci.org/tranql"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This adds a second tranql env variable `REACT_APP_TRANQL_URL` in addition to `REACT_APP_TRANQL_ENABLED`.

It could also be changed to just a tranql URL variable and then if it's enabled or not could be derived from whether the URL variable is set, if this would be preferable.