### PR TITLE
Add env variable to track deployment namespace name

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -92,6 +92,10 @@ spec:
                 configMapKeyRef:
                   name: {{ include "ui.fullname" . }}-config
                   key: hidden_support_sections
+            - name: REACT_APP_DEPLOYMENT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Will be used by analytics to track which deployment events are originating from, i.e. to differentiate between events from dev  and prod.