### PR TITLE
Meta title/description values

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "ui.labels" . | nindent 4 }}
 data:
+  meta_title: {{ .Values.config.meta.title | quote }}
+  meta_description: {{ .Values.config.meta.description | quote }}
   analytics: {{ .Values.config.analytics.token | quote }}
   appstore_asset_branch: {{ .Values.config.appstore_asset_branch }}
   brand_name: {{ .Values.config.brand_name }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -97,6 +97,16 @@ spec:
                 configMapKeyRef:
                   key: workspaces_enabled
                   name: {{ include "ui.fullname" . }}-config
+            - name: META_TITLE
+              valueFrom:
+                configMapKeyRef:
+                  key: meta_title
+                  name: {{ include "ui.fullname" . }}-config
+            - name: META_DESCRIPTION
+              valueFrom:
+                configMapKeyRef:
+                  key: meta_description
+                  name: {{ include "ui.fullname" . }}-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -57,6 +57,11 @@ ingress:
   #      - chart-example.local
 
 config:
+  meta:
+    # These will configure what displays in the browser tab title
+    # and what shows when a link preview is displayed describing the page.
+    title: HeLx UI
+    description: HeLx UI
   analytics:
     token: "0c39f8410fd548bfa1976957d0248289"
   appstore_asset_branch: "master"


### PR DESCRIPTION
These values will allow configuration of the page title (e.g. browser tab name) and the meta description tag. Specifically relevant to dug instances since HeLx UI is a confusing title. Also fixes dynamic link previews (e.g. displayed when pasting URLs into an application such as slack).

For dug 0.9 release.