### PR TITLE
FEAT: adding a setting to configure the landing space for the UI

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "6.0.1"
+appVersion: "6.1.0"

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -18,4 +18,12 @@ data:
   search_url: '{{ .Values.config.search.url }}'
   tranql_url: {{ .Values.config.tranql_url | quote }}
   workspaces_enabled: {{ .Values.config.workspaces.enabled | quote }}
+  {{- if and (eq .Values.config.workspaces.enabled "true") (eq .Values.config.search.enabled "false") }}
+  default_space: "workspaces"
+  {{- else if and (eq .Values.config.workspaces.enabled "false") (eq .Values.config.search.enabled "true") }}
+  default_space: "search"
+  {{- else if and (eq .Values.config.workspaces.enabled "true") (eq .Values.config.search.enabled "true") }}
   default_space: {{ .Values.config.default_space | quote }}
+  {{- else }}
+  default_space: "support"
+  {{- end }}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -18,3 +18,4 @@ data:
   search_url: '{{ .Values.config.search.url }}'
   tranql_url: {{ .Values.config.tranql_url | quote }}
   workspaces_enabled: {{ .Values.config.workspaces.enabled | quote }}
+  default_space: {{ .Values.config.default_space | quote }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -107,6 +107,11 @@ spec:
                 configMapKeyRef:
                   key: workspaces_enabled
                   name: {{ include "ui.fullname" . }}-config
+            - name: REACT_APP_DEFAULT_SPACE
+              valueFrom:
+                configMapKeyRef:
+                  key: default_space
+                  name: {{ include "ui.fullname" . }}-config
             - name: META_TITLE
               valueFrom:
                 configMapKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -78,7 +78,7 @@ config:
   tranql_url: 'https:\/\/helx.renci.org\/tranql\/'
   workspaces:
     enabled: "true"
-
+  default_space: "workspaces"
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/values.yaml
+++ b/values.yaml
@@ -78,7 +78,7 @@ config:
   tranql_url: 'https:\/\/helx.renci.org\/tranql\/'
   workspaces:
     enabled: "true"
-  default_space: "workspaces"
+  default_space: "search"
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR is in conjunction with https://github.com/helxplatform/helx-ui/pull/286 to add config.default_space setting in the chart. This sets the landing space for the target website.